### PR TITLE
Make rbenv available after sourcing the install recipe

### DIFF
--- a/ruby/rbenv.sh
+++ b/ruby/rbenv.sh
@@ -43,5 +43,7 @@ else
   echo 'export RBENV_ROOT="/usr/local/rbenv"' >> /etc/profile.d/rbenv.sh
   echo 'export PATH="$RBENV_ROOT/bin:$PATH"' >> /etc/profile.d/rbenv.sh
   echo 'eval "$(rbenv init -)"' >> /etc/profile.d/rbenv.sh
-  source /etc/profile.d/rbenv.sh
 fi
+
+# make rbenv available
+source /etc/profile.d/rbenv.sh


### PR DESCRIPTION
I've had problems using rbenv in later runs with sunzi. This is because on a second run of the script, rbenv isn't sourced. I've now corrected this. Please tell me if that's the way you like it to have :)
