### PR TITLE
RVM now signs / verifies releases

### DIFF
--- a/ruby/rvm.sh
+++ b/ruby/rvm.sh
@@ -3,6 +3,7 @@
 if [ -d /usr/local/rvm ]; then
   echo 'RVM already installed'
 else
+  curl -sSL https://rvm.io/mpapis.asc | gpg --import -
   curl -L https://get.rvm.io | bash -s stable
   echo '[[ -s /usr/local/rvm/scripts/rvm ]] && source /usr/local/rvm/scripts/rvm' >> ~/.bash_profile
 fi


### PR DESCRIPTION
This recipe fails with recent versions of RVM which sign & verifies releases. See https://rvm.io/rvm/security